### PR TITLE
Switch docker build to dev profile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ COPY ./target/pazuzu-registry.jar /usr/pazuzu
 COPY scm-source.json /
 WORKDIR /usr/pazuzu
 EXPOSE 8080
-CMD ["java", "-jar", "pazuzu-registry.jar"]
+CMD ["java", "-jar", "pazuzu-registry.jar", "--spring.profiles.active=dev"]


### PR DESCRIPTION
For the time being the `production` profile does not work (zAuth problems), so to be able to test continuous deployment we can switch temporarily to `dev` profile. 