### PR TITLE
Issue #30 Implement simple Oauth authentication/authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
             <version>3.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/zalando/pazuzu/api/ApiUrls.java
+++ b/src/main/java/org/zalando/pazuzu/api/ApiUrls.java
@@ -1,0 +1,18 @@
+package org.zalando.pazuzu.api;
+
+public final class ApiUrls {
+
+    /*
+     * Ant matcher used for auth config.
+     */
+    public static final String BASE_API_ANT_MATCHER = "/api/**";
+
+    // Health endpoint
+    public static final String HEALTH =  "/api/health";
+
+    // Features endpoints.
+    public static final String FEATURES = "/api/features";
+    public static final String FEATURE_NAME = "/api/features/{featureName}";
+
+    private ApiUrls() {}
+}

--- a/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
+++ b/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.zalando.pazuzu.api.ApiUrls;
 import org.zalando.stups.oauth2.spring.security.expression.ExtendedOAuth2WebSecurityExpressionHandler;
 import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
 import org.zalando.stups.oauth2.spring.server.DefaultTokenInfoRequestExecutor;
@@ -82,11 +83,11 @@ public class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.NEVER)
         .and()
             .authorizeRequests()
-                .antMatchers("/api/health").permitAll()
-                .antMatchers(HttpMethod.POST, "/api/**").access(scopeMatcher)
-                .antMatchers(HttpMethod.PUT, "/api/**").access(adminMatcher)
-                .antMatchers(HttpMethod.DELETE, "/api/**").access(adminMatcher)
-                .antMatchers(HttpMethod.GET, "/api/**").permitAll();
+                .antMatchers(ApiUrls.HEALTH).permitAll()
+                .antMatchers(HttpMethod.POST, ApiUrls.BASE_API_ANT_MATCHER).access(scopeMatcher)
+                .antMatchers(HttpMethod.PUT, ApiUrls.BASE_API_ANT_MATCHER).access(adminMatcher)
+                .antMatchers(HttpMethod.DELETE, ApiUrls.BASE_API_ANT_MATCHER).access(adminMatcher)
+                .antMatchers(HttpMethod.GET, ApiUrls.BASE_API_ANT_MATCHER).permitAll();
         // @formatter:on
     }
 

--- a/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
+++ b/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
@@ -1,9 +1,11 @@
 package org.zalando.pazuzu.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
@@ -17,13 +19,22 @@ import org.zalando.stups.oauth2.spring.server.ExecutorWrappers;
 import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
 import org.zalando.stups.tokens.config.AccessTokensBeanProperties;
 
+import java.util.Iterator;
+import java.util.List;
+
 @Configuration
 @EnableResourceServer
-@Profile(value = "production")
+@Profile(value = {"production", "test_oauth"})
 public class OAuthConfiguration extends ResourceServerConfigurerAdapter {
 
     @Autowired
     private AccessTokensBeanProperties accessTokensBeanProperties;
+
+    private static final String scopeMatcher = "#oauth2.hasScope('uid')";
+    private String adminMatcher;
+
+    @Value("#{'${pazuzu-registry.admins}'.split(',')}")
+    private List<String> adminList;
 
     @Override
     public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
@@ -31,20 +42,51 @@ public class OAuthConfiguration extends ResourceServerConfigurerAdapter {
         resources.expressionHandler(new ExtendedOAuth2WebSecurityExpressionHandler());
     }
 
+    private String buildAdminUserMatcher() {
+        Iterator<String> iterator = adminList.iterator();
+        StringBuilder result = new StringBuilder();
+
+        result.append(scopeMatcher);
+
+        if (adminList != null && !adminList.isEmpty()) {
+            result.append(" and (");
+
+            while (iterator.hasNext()) {
+                result.append("authentication.name.equals('");
+                result.append(iterator.next());
+                result.append("')");
+
+                if (iterator.hasNext()) {
+                    result.append(" or ");
+                }
+            }
+            result.append(")");
+        }
+
+        return result.toString();
+    }
+
     @Override
     public void configure(final HttpSecurity http) throws Exception {
+
+        if (adminMatcher == null || adminMatcher.isEmpty()) {
+            adminMatcher = buildAdminUserMatcher();
+        }
 
         // @formatter:off
         http
             .httpBasic().disable()
-            .requestMatchers().antMatchers("/api/**")
+                .requestMatchers().antMatchers("/**")
         .and()
             .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.NEVER)
         .and()
             .authorizeRequests()
                 .antMatchers("/api/health").permitAll()
-                .antMatchers("/api/**").access("#oauth2.hasScope('uid')");
+                .antMatchers(HttpMethod.POST, "/api/**").access(scopeMatcher)
+                .antMatchers(HttpMethod.PUT, "/api/**").access(adminMatcher)
+                .antMatchers(HttpMethod.DELETE, "/api/**").access(adminMatcher)
+                .antMatchers(HttpMethod.GET, "/api/**").permitAll();
         // @formatter:on
     }
 

--- a/src/test/java/org/zalando/pazuzu/ApiAuthTest.java
+++ b/src/test/java/org/zalando/pazuzu/ApiAuthTest.java
@@ -1,0 +1,277 @@
+package org.zalando.pazuzu;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.WebIntegrationTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.zalando.pazuzu.mock.ResourceServerTokenServicesMock;
+import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
+import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { PazuzuAppLauncher.class, ResourceServerTokenServicesMock.class })
+@WebIntegrationTest(randomPort = true)
+public class ApiAuthTest extends AbstractComponentTest {
+    @Autowired
+    private TokenInfoResourceServerTokenServices resourceServerTokenServices;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    private MockMvc mockMvc;
+
+    private static final String user = "user";
+    private static final String admin = "test";
+    private static final String VALID_TOKEN = "TOKEN_1234567890";
+
+    private static final String body = "{\n" +
+            "  \"name\": \"python\",\n" +
+            "  \"docker_data\": \"RUN python\",\n" +
+            "  \"test_instruction\": \"python -V\",\n" +
+            "  \"dependencies\": []\n" +
+            "}";
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(springSecurityFilterChain)
+                .alwaysDo(print())
+                .build();
+    }
+
+    private OAuth2Authentication buildTokenValidOauthResponse(final String uid) {
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put("uid", uid);
+        responseMap.put("scope", Stream.of("uid").collect(Collectors.toList()));
+        responseMap.put("token_type", "Bearer");
+        responseMap.put("expires_in", "4000");
+        responseMap.put("access_token", VALID_TOKEN);
+
+        return new DefaultAuthenticationExtractor().extractAuthentication(responseMap, "what_up");
+    }
+
+    @After
+    public void clearTokenServiceMocks() {
+        //  Clear out any token service mocking between the test methods to allow us to do both
+        //  positive and negative auth testing in the same context.
+        Mockito.reset(this.resourceServerTokenServices);
+    }
+
+    /**
+     * Test post feature without oauth.
+     * @throws Exception
+     */
+    @Test
+    public void postFeaturesNoOAuth2() throws Exception {
+        mockMvc.perform(post("/api/features")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("unauthorized")));
+    }
+
+    /**
+     * Test put feature without oauth.
+     * @throws Exception
+     */
+    @Test
+    public void putFeaturesNoOAuth2() throws Exception {
+        mockMvc.perform(put("/api/features")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("unauthorized")));
+    }
+
+    /**
+     * Test delete feature without oauth.
+     * @throws Exception
+     */
+    @Test
+    public void deleteFeaturesNoOAuth2() throws Exception {
+        mockMvc.perform(delete("/api/features")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("unauthorized")));
+    }
+
+
+    /**
+     * Test post feature with invalid token.
+     * @throws Exception
+     */
+    @Test
+    public void postFeaturesInvalidToken() throws Exception {
+        mockMvc.perform(post("/api/features")
+                .header("Authorization", "Bearer " + "fake")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("invalid_token")));
+    }
+
+    /**
+     * Test put feature with invalid token.
+     * @throws Exception
+     */
+    @Test
+    public void putFeaturesInvalidToken() throws Exception {
+        mockMvc.perform(put("/api/features")
+                .header("Authorization", "Bearer " + "fake")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("invalid_token")));
+    }
+
+    /**
+     * Test delete feature with invalid token.
+     * @throws Exception
+     */
+    @Test
+    public void deleteFeaturesInvalidToken() throws Exception {
+        mockMvc.perform(delete("/api/features")
+                .header("Authorization", "Bearer " + "fake")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error", is("invalid_token")));
+    }
+
+    /**
+     * Test getting features without auth.
+     * @throws Exception
+     */
+    @Test
+    public void getFeaturesSuccess() throws Exception {
+        mockMvc.perform(get("/api/features")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Test post feature as normal user.
+     */
+    @Test
+    public void postFeaturesAsUser() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(user));
+
+        mockMvc.perform(post("/api/features")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+    /**
+     * Test put feature as normal user.
+     */
+    @Test
+    public void putFeaturesAsUser() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(user));
+
+        mockMvc.perform(put("/api/features/python")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test delete feature as normal user.
+     */
+    @Test
+    public void deleteFeaturesAsUser() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(user));
+
+        mockMvc.perform(delete("/api/features/python")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Test post feature as admin.
+     */
+    @Test
+    public void postFeaturesAsAdmin() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(admin));
+
+        mockMvc.perform(post("/api/features")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+    }
+
+    /**
+     * Test put feature as admin.
+     */
+    @Test
+    public void putFeaturesAsAdmin() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(admin));
+
+        mockMvc.perform(post("/api/features")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(put("/api/features/python")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Test delete feature as admin.
+     */
+    @Test
+    public void deleteFeaturesAsAdmin() throws Exception {
+        when(this.resourceServerTokenServices.loadAuthentication(anyString())).thenReturn(buildTokenValidOauthResponse(admin));
+
+        mockMvc.perform(post("/api/features")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/features/python")
+                .header("Authorization", "Bearer " + VALID_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/org/zalando/pazuzu/ApiDiscoveryTest.java
+++ b/src/test/java/org/zalando/pazuzu/ApiDiscoveryTest.java
@@ -3,9 +3,11 @@ package org.zalando.pazuzu;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles(profiles = "test")
 public class ApiDiscoveryTest extends AbstractComponentTest {
 
     @Test

--- a/src/test/java/org/zalando/pazuzu/FeatureApiTest.java
+++ b/src/test/java/org/zalando/pazuzu/FeatureApiTest.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.zalando.pazuzu.exception.ErrorDto;
 import org.zalando.pazuzu.feature.FeatureDto;
 import org.zalando.pazuzu.feature.FeatureFullDto;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles(profiles = "test")
 public class FeatureApiTest extends AbstractComponentTest {
 
     @Test

--- a/src/test/java/org/zalando/pazuzu/mock/ResourceServerTokenServicesMock.java
+++ b/src/test/java/org/zalando/pazuzu/mock/ResourceServerTokenServicesMock.java
@@ -1,0 +1,15 @@
+package org.zalando.pazuzu.mock;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.zalando.stups.oauth2.spring.server.TokenInfoResourceServerTokenServices;
+
+@Configuration
+public class ResourceServerTokenServicesMock {
+    @Bean
+    public ResourceServerTokenServices customResourceTokenServices() {
+        return Mockito.mock(TokenInfoResourceServerTokenServices.class);
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -1,13 +1,19 @@
 tokens:
-  autoStartup: false
-  access-token-uri: https://token.services.auth.zalando.com/oauth2/access_token?realm=/services
-  credentials-directory: /meta/credentials
-  token-info-uri: https://info.services.auth.zalando.com/oauth2/tokeninfo
-  expose-client-credential-provider: true
-  token-configuration-list:
-   - token-id: kio
-     scopes:
-      - uid
+    accessTokenUri: http://localhost:9191/access_token?realm=whatever
+    credentialsDirectory: ${user.dir}/somepath/credentials
+    refreshPercentLeft: 30
+    warnPercentLeft: 10
+    autoStartup: true
+    start-after-creation: false
+    use-existing-scheduler: false
+
+    token-configuration-list:
+        - tokenId: firstService
+          scopes:
+            - uid
+
+pazuzu-registry:
+  admins: test
 
 twintip:
   mapping: /api
@@ -19,7 +25,7 @@ security:
 
 spring:
   profiles:
-    active: test
+    active: test_oauth
   datasource:
     url: jdbc:hsqldb:mem:testdb;sql.syntax_pgs=true
     username: sa


### PR DESCRIPTION
This implements a simple system for authenticating users through Oauth.
Currently it only supports a stups setup, but later it should be
possible to use any oauth service for authentication.

Authorization is handled by defining a list of admin users in
application.yml or the equvalent environtment variable:

    pazuzu-registry:
      admins: user1,user2

The endpoint `/api/**` for methods `PUT` and `DELETE` are only open for
admins, and `POST` is only allowed by authenticated users.
`GET` is possible without login for any endpoint.

Closes #30