### PR TITLE
Revamp error handling

### DIFF
--- a/src/main/java/org/zalando/pazuzu/exception/CommonErrors.java
+++ b/src/main/java/org/zalando/pazuzu/exception/CommonErrors.java
@@ -1,0 +1,8 @@
+package org.zalando.pazuzu.exception;
+
+public class CommonErrors {
+    public static final Error INTERNAL_SERVER_ERROR = new Error("internal_server_error", "An internal server error has occurred");
+    public static final Error BAD_JSON = new Error("json_not_parsable", "Failed to parse incoming json");
+    public static final Error CONTAINER_NOT_FOUND = new Error("container_not_found", "Container was not found");
+    public static final Error ITEM_NOT_FOUND = new Error("item_not_found", "Item not found");
+}

--- a/src/main/java/org/zalando/pazuzu/exception/Error.java
+++ b/src/main/java/org/zalando/pazuzu/exception/Error.java
@@ -1,30 +1,21 @@
 package org.zalando.pazuzu.exception;
 
 
-public enum Error {
+public class Error {
 
-    BAD_JSON("json_not_parsable", "Failed to parse incoming json"),
-    CONTAINER_NOT_FOUND("container_not_found", "Container was not found"),
-    FEATURE_DUPLICATE("feature_duplicate", "Feature with this name already exists"),
-    FEATURE_NAME_EMPTY("feature_name_empty", "Feature name is empty"),
-    FEATURE_NOT_FOUND("feature_not_found", "Feature was not found"),
-    FEATURE_NOT_DELETABLE_DUE_TO_REFERENCES("feature_not_deletable_due_to_references", "Can't delete feature because it still has references"),
-    FEATURE_HAS_RECURSIVE_DEPENDENCY("feature_has_recursive_dependency", "Recursive dependencies found"),
-    INTERNAL_SERVER_ERROR("internal_server_error", "An internal server error has occurred");
+    public final String code;
+    public final String message;
 
-    private final String code;
-    private final String message;
-
-    Error(String code, String message) {
+    public Error(String code, String message) {
         this.code = code;
         this.message = message;
     }
 
-    public String getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
+    @Override
+    public String toString() {
+        return "Error{" +
+                "code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
     }
 }

--- a/src/main/java/org/zalando/pazuzu/exception/ErrorDto.java
+++ b/src/main/java/org/zalando/pazuzu/exception/ErrorDto.java
@@ -13,18 +13,21 @@ public class ErrorDto {
     @JsonProperty("detailed_message")
     private String detailedMessage;
 
-    public ErrorDto(Error error) {
-        this.code = error.getCode();
-        this.message = error.getMessage();
+    public ErrorDto() {
     }
 
     public ErrorDto(Error error, String detailedMessage) {
-        this.code = error.getCode();
-        this.message = error.getMessage();
+        this.code = error.code;
+        this.message = error.message;
         this.detailedMessage = detailedMessage;
     }
 
-    public ErrorDto() {
+    public ErrorDto(Error error) {
+        this(error, "");
+    }
+
+    public ErrorDto(ServiceException ex) {
+        this(ex.getError(), ex.getMessage());
     }
 
     public String getCode() {

--- a/src/main/java/org/zalando/pazuzu/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/zalando/pazuzu/exception/GlobalExceptionHandler.java
@@ -18,30 +18,31 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     @ResponseBody
     public ErrorDto featureNotExistingException(BadRequestException exception) {
-        return new ErrorDto(exception.getError(), exception.getDetailedMessage());
+        LOG.error(exception.getMessage(), exception);
+        return new ErrorDto(exception);
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NotFoundException.class)
     @ResponseBody
     public ErrorDto notFoundException(NotFoundException exception) {
-        return new ErrorDto(exception.getError(), exception.getDetailedMessage());
+        LOG.error(exception.getMessage(), exception);
+        return new ErrorDto(exception);
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ResponseBody
     public ErrorDto failedToParseJsonException(HttpMessageNotReadableException exception) {
-        return new ErrorDto(Error.BAD_JSON);
+        LOG.error(exception.getMessage(), exception);
+        return new ErrorDto(CommonErrors.BAD_JSON);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ErrorDto exception(Exception exception) {
-        if (LOG.isErrorEnabled()) {
-            LOG.error(exception.getMessage(), exception);
-        }
-        return new ErrorDto(Error.INTERNAL_SERVER_ERROR);
+        LOG.error(exception.getMessage(), exception);
+        return new ErrorDto(CommonErrors.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/org/zalando/pazuzu/exception/ServiceException.java
+++ b/src/main/java/org/zalando/pazuzu/exception/ServiceException.java
@@ -1,25 +1,20 @@
 package org.zalando.pazuzu.exception;
 
 
-public class ServiceException extends Exception {
-    private Error error;
-    private String detailedMessage;
+public class ServiceException extends RuntimeException {
+    private final Error error;
 
     public ServiceException(Error error) {
-        super(error.getMessage());
+        super(error.message);
         this.error = error;
     }
 
     public ServiceException(Error error, String detailedMessage) {
+        super(detailedMessage);
         this.error = error;
-        this.detailedMessage = detailedMessage;
     }
 
     public Error getError() {
         return error;
-    }
-
-    public String getDetailedMessage() {
-        return detailedMessage;
     }
 }

--- a/src/main/java/org/zalando/pazuzu/feature/FeatureErrors.java
+++ b/src/main/java/org/zalando/pazuzu/feature/FeatureErrors.java
@@ -1,0 +1,12 @@
+package org.zalando.pazuzu.feature;
+
+
+import org.zalando.pazuzu.exception.Error;
+
+public class FeatureErrors {
+    public static final Error FEATURE_DUPLICATE = new Error("feature_duplicate", "Feature with this name already exists");
+    public static final Error FEATURE_NAME_EMPTY = new Error("feature_name_empty", "Feature name is empty");
+    public static final Error FEATURE_NOT_FOUND = new Error("feature_not_found", "Feature was not found");
+    public static final Error FEATURE_NOT_DELETABLE_DUE_TO_REFERENCES = new Error("feature_not_deletable_due_to_references", "Can't delete feature because it still has references");
+    public static final Error FEATURE_HAS_RECURSIVE_DEPENDENCY = new Error("feature_has_recursive_dependency", "Recursive dependencies found");
+}


### PR DESCRIPTION
Service exception made unchecked - allows reporting errors
from different layers.

Error is now a class - sub-modules may now report own errors
without interfering each other. However use of
generic error markers is likely sufficient (still unsure
that Error class is necessary).

Streamline handling of Error class.

GlobalExceptionHandler now reports all errors to logger.