### PR TITLE
Proper detail message on missing feature#70

### DIFF
--- a/src/main/java/org/zalando/pazuzu/exception/FeatureDuplicateException.java
+++ b/src/main/java/org/zalando/pazuzu/exception/FeatureDuplicateException.java
@@ -2,14 +2,15 @@ package org.zalando.pazuzu.exception;
 
 
 import javax.ws.rs.core.Response.Status;
+import java.util.Optional;
 
 public class FeatureDuplicateException extends ServiceException {
 
     private static final String CODE = "feature_duplicate";
     private static final String TITLE = "Feature with this name already exists";
 
-    public FeatureDuplicateException() {
-        super(Status.BAD_REQUEST, CODE, TITLE);
+    public FeatureDuplicateException(String detail) {
+        super(Status.BAD_REQUEST, CODE, TITLE, Optional.ofNullable(detail));
     }
 
 }

--- a/src/main/java/org/zalando/pazuzu/feature/FeatureRepository.java
+++ b/src/main/java/org/zalando/pazuzu/feature/FeatureRepository.java
@@ -3,12 +3,16 @@ package org.zalando.pazuzu.feature;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 public interface FeatureRepository extends CrudRepository<Feature, Integer>, FeatureRepositoryCustom {
 
     List<Feature> findByNameIgnoreCaseContaining(String name);
 
-    Feature findByName(String name);
+    Optional<Feature> findByName(String name);
+
+    Set<Feature> findByNameIn(Set<String> name);
 
     List<Feature> findByDependenciesContaining(Feature feature);
 }

--- a/src/main/java/org/zalando/pazuzu/feature/file/FileLinkService.java
+++ b/src/main/java/org/zalando/pazuzu/feature/file/FileLinkService.java
@@ -41,11 +41,9 @@ public class FileLinkService {
     }
 
     private Feature getFeature(String featureName) {
-        final Feature byName = featureRepository.findByName(featureName);
-        if (null == byName) {
-            throw new FeatureNotFoundException("Feature '" + featureName + "' is not found.");
-        }
-        return byName;
+        return featureRepository.findByName(featureName)
+                .orElseThrow(() -> new FeatureNotFoundException("Feature '" + featureName + "' is not found."));
+
     }
 
 }

--- a/src/test/java/org/zalando/pazuzu/FeatureApiTest.java
+++ b/src/test/java/org/zalando/pazuzu/FeatureApiTest.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.GET;
 
 public class FeatureApiTest extends AbstractComponentTest {
 


### PR DESCRIPTION
Implementation of #70 - adds information about which exactly features were not found in the `detail` field of the error response payload.

The PR #102 should be merged beforehand.


