### PR TITLE
cors-headers#104: Limited the allowed origins for security reasons

### DIFF
--- a/src/main/java/org/zalando/pazuzu/config/CorsConfiguration.java
+++ b/src/main/java/org/zalando/pazuzu/config/CorsConfiguration.java
@@ -1,0 +1,25 @@
+package org.zalando.pazuzu.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+public class CorsConfiguration {
+
+    @Value("${pazuzu.registry.cors.allowedOrigins:}")
+    private String allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurerAdapter() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/api/**").allowedOrigins(allowedOrigins);
+            }
+        };
+    }
+}

--- a/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
+++ b/src/main/java/org/zalando/pazuzu/config/OAuthConfiguration.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
+import org.springframework.web.cors.CorsUtils;
 import org.zalando.stups.oauth2.spring.security.expression.ExtendedOAuth2WebSecurityExpressionHandler;
 import org.zalando.stups.oauth2.spring.server.DefaultAuthenticationExtractor;
 import org.zalando.stups.oauth2.spring.server.DefaultTokenInfoRequestExecutor;
@@ -19,7 +20,7 @@ import org.zalando.stups.tokens.config.AccessTokensBeanProperties;
 
 @Configuration
 @EnableResourceServer
-@Profile(value = "production")
+@Profile(value = {"production", "oauth"})
 public class OAuthConfiguration extends ResourceServerConfigurerAdapter {
 
     @Autowired
@@ -43,6 +44,7 @@ public class OAuthConfiguration extends ResourceServerConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.NEVER)
                 .and()
                 .authorizeRequests()
+                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/api/health").permitAll()
                 .antMatchers("/api/**").access("#oauth2.hasScope('uid')");
         // @formatter:on

--- a/src/main/java/org/zalando/pazuzu/feature/FeaturesResource.java
+++ b/src/main/java/org/zalando/pazuzu/feature/FeaturesResource.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@CrossOrigin
 @RestController
 @RequestMapping(value = "/api/features")
 public class FeaturesResource {

--- a/src/main/java/org/zalando/pazuzu/feature/file/FileResource.java
+++ b/src/main/java/org/zalando/pazuzu/feature/file/FileResource.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
  * <p>
  * FIXME File paths are unsuitable generally as  "/" and filename extensions (suffixes) interfere with spring's request mapping.
  */
-@CrossOrigin
 @RestController
 @RequestMapping(value = "/api/files")
 public class FileResource {

--- a/src/main/java/org/zalando/pazuzu/feature/tag/TagResource.java
+++ b/src/main/java/org/zalando/pazuzu/feature/tag/TagResource.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 /**
  * Created by vpavlyshyn on 13/06/16.
  */
-@CrossOrigin
 @RestController
 @RequestMapping(value = "/api/tags")
 public class TagResource {

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -34,4 +34,4 @@ endpoints:
 pazuzu:
   registry:
     cors:
-      allowedOrigins: http://localhost:8080
+      allowedOrigins: https://localhost:8080

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -30,3 +30,8 @@ endpoints:
   health:
     enabled: true
     path: /api/health
+
+pazuzu:
+  registry:
+    cors:
+      allowedOrigins: http://localhost:8080

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -30,3 +30,8 @@ endpoints:
 
 server:
   use-forward-headers: true
+
+pazuzu:
+  registry:
+    cors:
+      allowedOrigins: https://pazuzu-ui.mentoring.zalan.do

--- a/src/test/java/org/zalando/pazuzu/CorsTest.java
+++ b/src/test/java/org/zalando/pazuzu/CorsTest.java
@@ -1,0 +1,42 @@
+package org.zalando.pazuzu;
+
+import org.junit.Test;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class CorsTest extends AbstractComponentTest {
+
+    @Test
+    public void testShouldSuccessfullyReturnCorsHeadersForValidOrigin() {
+        // given
+        String validOrigin = "http://localhost:8080";
+        HttpEntity<Void> entity = createHttpEntityWithOrigin(validOrigin);
+
+        // when
+        ResponseEntity<Void> response = template.exchange(url("/api/features"), HttpMethod.GET, entity, Void.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getAccessControlAllowOrigin()).isEqualTo(validOrigin);
+    }
+
+    @Test
+    public void testShouldReturnAccessForbiddenForInvalidOrigin() {
+        // given
+        String invalidOrigin = "http://omg-this-is-not-a-valid-origin:8080";
+        HttpEntity<Void> entity = createHttpEntityWithOrigin(invalidOrigin);
+
+        // when
+        ResponseEntity<Void> response = template.exchange(url("/api/features"), HttpMethod.GET, entity, Void.class);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private HttpEntity<Void> createHttpEntityWithOrigin(String origin) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setOrigin(origin);
+        return new HttpEntity<>(headers);
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -33,3 +33,8 @@ endpoints:
   health:
     enabled: true
     path: /api/health
+
+pazuzu:
+  registry:
+    cors:
+      allowedOrigins: http://localhost:8080


### PR DESCRIPTION
Limited the `Access-Control-Allow-Origin` to a single origin for security reasons. 

Part of cors headers #104 